### PR TITLE
Simplify div of monomial and variable

### DIFF
--- a/src/nl_to_polynomial.jl
+++ b/src/nl_to_polynomial.jl
@@ -105,13 +105,25 @@ end
 _checked_div(a, b) = a / b
 
 function _checked_div(
-    a::DynamicPolynomials.Monomial,
-    b::DynamicPolynomials.Variable,
+    α,
+    p::MP.AbstractPolynomialLike,
+)
+    if !MP.isconstant(p)
+        throw(
+            InvalidNLExpression("Cannot convert `α / ($p)` to a polynomial."),
+        )
+    end
+    return MP.constant_term(α / MP.convert_to_constant(p), p)
+end
+
+function _checked_div(
+    a::MP.AbstractPolynomialLike,
+    b::MP.AbstractPolynomialLike,
 )
     divisor, remainder = Base.divrem(a, b)
     if !iszero(remainder)
         throw(
-            InvalidNLExpression("Cannot convert `$(a) / $b` into a polynomial"),
+            InvalidNLExpression("Cannot convert `($(a)) / ($b)` into a polynomial as the Euclidean division has a nonzero remainder `$remainder` (the divisor is `$divisor`)."),
         )
     end
     return divisor

--- a/src/nl_to_polynomial.jl
+++ b/src/nl_to_polynomial.jl
@@ -94,19 +94,25 @@ function _to_polynomial!(
         return a^b
     elseif _is_operator(expr, :/) && length(operands) == 2
         a, b = _to_polynomial!.(Ref(d), T, operands)
-        return a / b
-        # TODO(odow): see PR#113
-        # divisor, remainder = Base.divrem(a, b)
-        # if iszero(remainder)
-        #     return divisor
-        # else
-        #     return a / b
-        # end
+        return _checked_div(a, b)
     elseif _is_variable(expr)
         return _to_polynomial!(d, T, operands[1])
     else
         throw(InvalidNLExpression("Cannot convert `$(expr)` into a polynomial"))
     end
+end
+
+_checked_div(a, b) = a / b
+
+function _checked_div(
+    a::DynamicPolynomials.Monomial,
+    b::DynamicPolynomials.Variable,
+)
+    divisor, remainder = Base.divrem(a, b)
+    if iszero(remainder)
+        return divisor
+    end
+    return a / b
 end
 
 function _to_polynomial(expr, ::Type{T}) where {T}

--- a/src/nl_to_polynomial.jl
+++ b/src/nl_to_polynomial.jl
@@ -109,10 +109,12 @@ function _checked_div(
     b::DynamicPolynomials.Variable,
 )
     divisor, remainder = Base.divrem(a, b)
-    if iszero(remainder)
-        return divisor
+    if !iszero(remainder)
+        throw(
+            InvalidNLExpression("Cannot convert `$(a) / $b` into a polynomial"),
+        )
     end
-    return a / b
+    return divisor
 end
 
 function _to_polynomial(expr, ::Type{T}) where {T}

--- a/src/nl_to_polynomial.jl
+++ b/src/nl_to_polynomial.jl
@@ -104,14 +104,9 @@ end
 
 _checked_div(a, b) = a / b
 
-function _checked_div(
-    α,
-    p::MP.AbstractPolynomialLike,
-)
+function _checked_div(α, p::MP.AbstractPolynomialLike)
     if !MP.isconstant(p)
-        throw(
-            InvalidNLExpression("Cannot convert `α / ($p)` to a polynomial."),
-        )
+        throw(InvalidNLExpression("Cannot convert `α / ($p)` to a polynomial."))
     end
     return MP.constant_term(α / MP.convert_to_constant(p), p)
 end
@@ -123,7 +118,9 @@ function _checked_div(
     divisor, remainder = Base.divrem(a, b)
     if !iszero(remainder)
         throw(
-            InvalidNLExpression("Cannot convert `($(a)) / ($b)` into a polynomial as the Euclidean division has a nonzero remainder `$remainder` (the divisor is `$divisor`)."),
+            InvalidNLExpression(
+                "Cannot convert `($(a)) / ($b)` into a polynomial as the Euclidean division has a nonzero remainder `$remainder` (the divisor is `$divisor`).",
+            ),
         )
     end
     return divisor

--- a/test/qcqp.jl
+++ b/test/qcqp.jl
@@ -240,10 +240,12 @@ function test_scalar_nonlinear_function_div_rem_err(x, y, T)
     PolyJuMP.@variable(model, y)
     PolyJuMP.@objective(model, Min, x^3 / y)
     @test_throws PolyJuMP.InvalidNLExpression PolyJuMP.optimize!(model)
+    PolyJuMP.@objective(model, Min, 2 / y)
+    @test_throws PolyJuMP.InvalidNLExpression PolyJuMP.optimize!(model)
+    PolyJuMP.@objective(model, Min, 2 / (x * y^2 - y^2 * x - 1))
+    PolyJuMP.optimize!(model)
     return
 end
-
-test_scalar_nonlinear_function_div_rem_number(x, y, ::Type{Int}) = nothing
 
 function test_scalar_nonlinear_function_div_rem_number(x, y, T)
     inner = Model{T}()
@@ -251,7 +253,7 @@ function test_scalar_nonlinear_function_div_rem_number(x, y, T)
         return PolyJuMP.QCQP.Optimizer{T}(MOI.Utilities.MockOptimizer(inner))
     end
     PolyJuMP.@variable(model, x)
-    PolyJuMP.@objective(model, Min, x^3 / 2)
+    PolyJuMP.@objective(model, Min, 4x^3 / 2)
     PolyJuMP.optimize!(model)
     @test MOI.get(inner, MOI.NumberOfVariables()) == 2
     F, S = MOI.ScalarQuadraticFunction{T}, MOI.EqualTo{T}

--- a/test/qcqp.jl
+++ b/test/qcqp.jl
@@ -231,9 +231,21 @@ function test_scalar_nonlinear_function_div_rem_zero(x, y, T)
     return
 end
 
-test_scalar_nonlinear_function_div_rem_one(x, y, ::Type{Int}) = nothing
+function test_scalar_nonlinear_function_div_rem_err(x, y, T)
+    inner = Model{T}()
+    model = PolyJuMP.JuMP.GenericModel{T}() do
+        return PolyJuMP.QCQP.Optimizer{T}(MOI.Utilities.MockOptimizer(inner))
+    end
+    PolyJuMP.@variable(model, x)
+    PolyJuMP.@variable(model, y)
+    PolyJuMP.@objective(model, Min, x^3 / y)
+    @test_throws PolyJuMP.InvalidNLExpression PolyJuMP.optimize!(model)
+    return
+end
 
-function test_scalar_nonlinear_function_div_rem_one(x, y, T)
+test_scalar_nonlinear_function_div_rem_number(x, y, ::Type{Int}) = nothing
+
+function test_scalar_nonlinear_function_div_rem_number(x, y, T)
     inner = Model{T}()
     model = PolyJuMP.JuMP.GenericModel{T}() do
         return PolyJuMP.QCQP.Optimizer{T}(MOI.Utilities.MockOptimizer(inner))


### PR DESCRIPTION
Closes #117

@blegat I got method errors with `divrem` and something like `x^3 / 2`. What types are safe to call it with?