### PR TITLE
Add Julia v1.6 to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1', '1.6']  # Test against LTS
+        version: ['1'] # , '1.6']  # LTS is failing because HomotopyContinuation is a dependency of the tests it doesn't support the LTS
         os: [ubuntu-latest, macOS-latest, windows-latest]
         arch: [x64]
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1']  # Test against LTS
+        version: ['1', '1.6']  # Test against LTS
         os: [ubuntu-latest, macOS-latest, windows-latest]
         arch: [x64]
         include:

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ StarAlgebras = "0c0c59c1-dc5f-42e9-9a8b-b5dc384a6cd1"
 [compat]
 DataStructures = "0.18"
 DynamicPolynomials = "0.5"
-IntervalArithmetic = "0.22"
+IntervalArithmetic = "0.20, 0.21, 0.22" # Needs v0.20 for Julia v1.6 support
 JuMP = "1"
 MathOptInterface = "1"
 MultivariateBases = "0.2"


### PR DESCRIPTION
IntervalArithmetics v0.22 does not support Julia v1.6. The lack of Julia v1.6 in ci prevented to see this